### PR TITLE
Add expires_in field for TokenResponse interface

### DIFF
--- a/src/AuthClient.ts
+++ b/src/AuthClient.ts
@@ -68,7 +68,8 @@ export default class AuthClient {
     const resp = await axios(request);
     return {
       access_token: resp.data.access_token,
-      refresh_token: resp.data.refresh_token
+      refresh_token: resp.data.refresh_token,
+      expires_in: resp.data.expires_in
     };
   }
 }

--- a/src/models/TokenResponse.ts
+++ b/src/models/TokenResponse.ts
@@ -1,4 +1,5 @@
 export interface TokenResponse {
     access_token: string;
     refresh_token?: string;
+    expires_in: number;
 }


### PR DESCRIPTION
The exchange token function is missing expires_in field. I follow the documentation an realize the sdk is missing that field.